### PR TITLE
Fix syntax error on compile and use actual JSON as the default context.

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -57,7 +57,7 @@
 				'source'      : '#main-content', 
 				'context'     : {
 					source   : '{{foo}}',
-					context  : "{{ foo : 'bar' }}",
+					context  : '{ "foo" : "bar" }',
 					samples  : handlebars_samples
 				}, 
 				'helpers' 	  : '', 


### PR DESCRIPTION
The default sample context on tryhandlebarsjs.com is invalid JSON, so it always causes a syntax error when you compile the template. This patch fixes the syntax error and makes it actual valid JSON.
